### PR TITLE
Fix bug with menu trying to display invalid characters

### DIFF
--- a/RarityMenu.cs
+++ b/RarityMenu.cs
@@ -144,7 +144,8 @@ namespace RarntyMenu
             MenuHandler.CreateText(ModName, menu, out _, 60, false, null, null, null, null);
             foreach (string mod in ModCards.Keys.OrderBy(m => m == "Vanilla" ? m : $"Z{m}"))
             {
-                ModGUI(MenuHandler.CreateMenu(mod, () => { }, menu, 60, true, true, menu.transform.parent.gameObject), mod);
+                var modNameSafe = System.Text.RegularExpressions.Regex.Replace(mod, @"[^0-9a-zA-Z]+", "");
+                ModGUI(MenuHandler.CreateMenu(modNameSafe, () => { }, menu, 60, true, true, menu.transform.parent.gameObject), mod);
             }
         }
 
@@ -153,7 +154,8 @@ namespace RarntyMenu
             MenuHandler.CreateText(mod.ToUpper(), menu, out _, 60, false, null, null, null, null);
             foreach (CardInfo card in ModCards[mod])
             {
-                MenuHandler.CreateText(card.cardName, menu, out _, 30, color: CardChoice.instance.GetCardColor(card.colorTheme));
+                var cardNameSafe = System.Text.RegularExpressions.Regex.Replace(card.cardName, @"[^0-9a-zA-Z]+", "");
+                MenuHandler.CreateText(cardNameSafe, menu, out _, 30, color: CardChoice.instance.GetCardColor(card.colorTheme));
                 Color common = new Color(0.0978f, 0.1088f, 0.1321f);
                 Color c = RarityUtils.GetRarityData(CardRaritys[card.name].Value != "DEFAULT" ? RarityUtils.GetRarity(CardRaritys[card.name].Value) : CardDefaultRaritys[card.name]).colorOff;
                 CardRaritysTexts[card.name] = CreateSliderWithoutInput(CardRaritys[card.name].Value, menu, 30, -1, maxRarity, CardRaritys[card.name].Value == "DEFAULT" ? -1 : (int)RarityUtils.GetRarity(CardRaritys[card.name].Value), (value) =>


### PR DESCRIPTION
```bash
[Error  : Unity Log] ArgumentException: Cannot use any of the following characters in section and key names: = \n \t \ " ' [ ]
Parameter name: key
Stack trace:
BepInEx.Configuration.ConfigDefinition.CheckInvalidConfigChars (System.String val, System.String name) (at <2e96006724e44cef876346c4d9580850>:0)
BepInEx.Configuration.ConfigDefinition..ctor (System.String section, System.String key) (at <2e96006724e44cef876346c4d9580850>:0)
BepInEx.Configuration.ConfigFile.Bind[T] (System.String section, System.String key, T defaultValue, System.String description) (at <2e96006724e44cef876346c4d9580850>:0)
RarntyMenu.RarityMenu.<Start>b__21_0 () (at <77e239be3e954fa893344ab5b10cb9b4>:0)
UnboundLib.ExtensionMethods+<ExecuteAfterFramesCoroutine>d__4.MoveNext () (at <caaaf3b2a164447db32faa360a7a51de>:0)
UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at <2774ccc3e0de4aef8525f5fbd178bef1>:0)
```

This should fix this issue.

Fixes #4, possibly #5